### PR TITLE
Make extension configuration available with the template constant editor

### DIFF
--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -1,8 +1,12 @@
 plugin.tx_hcaptcha {
   settings {
+    # cat=plugin.hcaptcha//03; type=string; label= hcaptcha api script
     apiScript = https://hcaptcha.com/1/api.js
+    # cat=plugin.hcaptcha//04; type=string; label= hcaptcha vérification server
     verificationServer = https://hcaptcha.com/siteverify
+    # cat=plugin.hcaptcha//01; type=string; label= hcaptcha public key (hcaptcha wording: "Site Key")
     publicKey = b3ac2551-431d-45f0-a5e9-c397d4054d9b
+    # cat=plugin.hcaptcha//02; type=string; label= hcaptcha private key (hcaptcha wording: "Secret Key")
     privateKey = 0x82f20B839DEC165594aF2Dd7C9344DBb0d08340f
   }
 }


### PR DESCRIPTION
[FEATURE] Fix #19 Add comments to make extension configuration available with the template constant editor